### PR TITLE
Pull request -- bug fix and typo

### DIFF
--- a/lib/Geo/Distance.pm
+++ b/lib/Geo/Distance.pm
@@ -149,7 +149,7 @@ sub new {
 
 Allows you to retrieve and set the formula that is currently being used to 
 calculate distances.  The availabel formulas are hsin, polar, cos, and mt.  hsin 
-is the default and mt/cos are depreciated in favor of hsin.  polar should be 
+is the default and mt/cos are deprecated in favor of hsin.  polar should be 
 used when calculating coordinates near the poles.
 
 =cut


### PR DESCRIPTION
Hi Aran.

I use Geo::Distance, but noticed that the SQL generated at around line 390 made DBDs powered by SQL::Statement (e.g. DBD::AnyData) die like this:

```
DBD::AnyData::db prepare failed: Bad table or column name: 'lon >=?' has chars not alphanumeric or underscore! at /usr/lib/perl5/site_perl/5.8.8/SQL/Statement.pm line 88 [for Statement " SELECT lon,lat,code FROM hub_lat_lon WHERE lon>=? AND lat>=? AND lon<=? AND lat<=? "] at /usr/lib/perl5/site_perl/5.8.8/Geo/Distance.pm line 392
```

I fixed this by putting some spaces in, e.g. "lon>=?" is now "lon >= ?"

You can verify that this is an issue with SQL::Statement by running this code:

```
use SQL::Statement;
my $parser = SQL::Parser->new();
$parser->parse('SELECT a FROM b WHERE c>=?');
```

Thanks for incorporating this fix!
